### PR TITLE
Output `resultPairs` instead of source data set

### DIFF
--- a/machine-learning-with-go/ml_with_go/example1/example1.ipynb
+++ b/machine-learning-with-go/ml_with_go/example1/example1.ipynb
@@ -209,7 +209,7 @@
    "outputs": [],
    "source": [
     "// Marshall the data in a pretty printed format.\n",
-    "jsonString, err := json.MarshalIndent(emojisims, \"\", \"  \")\n",
+    "jsonString, err := json.MarshalIndent(resultPairs, \"\", \"  \")\n",
     "if err != nil {\n",
     "    fmt.Println(err)\n",
     "}\n",


### PR DESCRIPTION
Race for the GopherCon ML Workshop prize! ;)

Output `similar_pairs.json` will end up looking like:
```json
[
  {
    "EmojiOne": {
      "Unicodelong": "\\U0001F3B5",
      "Unicodeshort": "U+1F3B5",
      "Title": "musical note"
    },
    "EmojiTwo": {
      "Unicodelong": "\\U0001F3B6",
      "Unicodeshort": "U+1F3B6",
      "Title": "musical notes"
    }
  },
  {
    "EmojiOne": {
      "Unicodelong": "\\U0001F38A",
      "Unicodeshort": "U+1F38A",
      "Title": "confetti ball"
    },
    "EmojiTwo": {
      "Unicodelong": "\\U0001F389",
      "Unicodeshort": "U+1F389",
      "Title": "party popper"
    }
  },
...
]
```