### PR TITLE
All results are printed out, not the filtered results where Human_Annotator_Agreement > 3.5

### DIFF
--- a/machine-learning-with-go/ml_with_go/example1/example1.ipynb
+++ b/machine-learning-with-go/ml_with_go/example1/example1.ipynb
@@ -209,7 +209,7 @@
    "outputs": [],
    "source": [
     "// Marshall the data in a pretty printed format.\n",
-    "jsonString, err := json.MarshalIndent(emojisims, \"\", \"  \")\n",
+    "jsonString, err := json.MarshalIndent(resultPairs, \"\", \"  \")\n",
     "if err != nil {\n",
     "    fmt.Println(err)\n",
     "}\n",


### PR DESCRIPTION
In the code after:

> Now let's save all of the similar emoji pairs to an output data file.

I was expecting to write out the mutated data set not the original data set. It seems less useful to write out the same file we just read in. I think it would be better to Read -> Modify -> Write.