### PR TITLE
fix index of example 2 graph #2

### DIFF
--- a/machine-learning-with-go/ml_with_go/example2/example2.ipynb
+++ b/machine-learning-with-go/ml_with_go/example2/example2.ipynb
@@ -226,7 +226,7 @@
    "outputs": [],
    "source": [
     "// Read the plot data from the second histogram.\n",
-    "plotBytes, err := GetGraph(plotNames[0])\n",
+    "plotBytes, err := GetGraph(plotNames[1])\n",
     "if err != nil {\n",
     "    fmt.Println(err)\n",
     "}\n",


### PR DESCRIPTION
Fixing the index of the second graph in example 2.

"// Read the plot data from the second histogram."