### PR TITLE
Use a different var for knn to prevent library name collision

### DIFF
--- a/machine-learning-with-go/ml_with_go/example3/example3.ipynb
+++ b/machine-learning-with-go/ml_with_go/example3/example3.ipynb
@@ -333,7 +333,7 @@
    "outputs": [],
    "source": [
     "// Define our kNN model.\n",
-    "knn := knn.NewKnnClassifier(\"euclidean\", \"linear\", 2)\n",
+    "knnModel := knn.NewKnnClassifier(\"euclidean\", \"linear\", 2)\n",
     "\n",
     "// This is to seed the random processes involved in building the\n",
     "// decision tree.\n",
@@ -372,7 +372,7 @@
    "source": [
     "// Use cross-fold validation to evaluate the kNN model\n",
     "// on 5 folds of the data set.\n",
-    "cv, err := evaluation.GenerateCrossFoldValidationConfusionMatrices(irisData, knn, 5)\n",
+    "cv, err := evaluation.GenerateCrossFoldValidationConfusionMatrices(irisData, knnModel, 5)\n",
     "if err != nil {\n",
     "    fmt.Println(err)\n",
     "}\n",


### PR DESCRIPTION
Rerunning this block in Jupyter results in 

```repl.go:2:8: type github.com/sjwhitworth/golearn/knn.KNNClassifier has no field or method "NewKnnClassifier": knn.NewKnnClassifier```

Rename knn => knnModel to not conflict with library import